### PR TITLE
Fix incorrect call register_rest_route

### DIFF
--- a/src/Utils/Router.php
+++ b/src/Utils/Router.php
@@ -9,7 +9,7 @@ class Router
         add_action('rest_api_init', function () use ($route) {
             $route['base'] = str_replace('{', '(?P<', $route['base']);
             $route['base'] = str_replace('}', '>\w+)', $route['base']);
-            register_rest_route($route['namespace'] . '/', $route['base'], [
+            register_rest_route($route['namespace'], '/' . $route['base'], [
                 'methods'             => $route['methods'],
                 'callback'            => $route['callback'],
                 'permission_callback' => isset($route['permission_callback']) ? $route['permission_callback'] : null,


### PR DESCRIPTION
Fix for register_rest_route was called incorrectly. Namespace must not start or end with a slash. Please see Debugging in WordPress for more information. (This message was added in version 5.4.2.)